### PR TITLE
Add a 'send_string' method to send a whole string of mixed upper and lower cases

### DIFF
--- a/src/keyboard/linux/mod.rs
+++ b/src/keyboard/linux/mod.rs
@@ -72,6 +72,14 @@ impl Keyboard {
         keycode
     }
 
+    pub fn send_string(&self, string: &String) {
+        string.chars().for_each(|c| {
+            c.to_lowercase().for_each(|sub_c| {
+                self.send_char(&sub_c, &c.is_uppercase())
+            });
+        });
+    }
+    
     /// top level send character function that converts char to keycode and executes send key
     pub fn send_char (&self, key:&char, shifted:&bool) {
         unsafe {

--- a/src/keyboard/macos/mod.rs
+++ b/src/keyboard/macos/mod.rs
@@ -51,6 +51,14 @@ impl Keyboard {
         self.release_key(KeyCode::SHIFT)
     }
 
+    pub fn send_string(&self, string: &String) {
+        string.chars().for_each(|c| {
+            c.to_lowercase().for_each(|sub_c| {
+                self.send_char(&sub_c, &c.is_uppercase())
+            });
+        });
+    }
+
     pub fn send_char(&self, key:&char, shifted:&bool) {
         let char_string = String::from(*key);
         let value = self.keymap.get(&char_string);

--- a/src/keyboard/windows/mod.rs
+++ b/src/keyboard/windows/mod.rs
@@ -86,8 +86,15 @@ impl Keyboard {
             sleep(Duration::from_micros(50));
         }
     }
-    
 
+    pub fn send_string(&self, string: &String) {
+        string.chars().for_each(|c| {
+            c.to_lowercase().for_each(|sub_c| {
+                self.send_char(&sub_c, &c.is_uppercase())
+            });
+        });
+    }
+    
     /// function used when sending input as string
     pub fn send_char(&self, key:&char, shifted:&bool) {
         let char_string = String::from(*key);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,6 +375,11 @@ impl RustAutoGui {
         for letter in input_string.chars() {
             self.keyboard.send_char(&letter, shifted);
         }
+    }   
+    
+     /// sends a whole string, automatically checks whether a character needs to be "shifted" or not
+    pub fn keyboard_string(&self, string: &String) {
+        self.keyboard.send_string(string);
     }
 
     /// executes keyboard command like "return" or "escape"


### PR DESCRIPTION
Hello,
as per title, i've added an helper to send a whole string rather than an array of key presses.
This might be redundant, and it does not work with special cases, not sure what's the best approach for that, i imagine we'd need another key map for that.

This seems to work fine
```rust
rustautogui.keyboard_string(&"HelLoOo".to_owned());
```

Anyhow - feel free to accept or reject this! 
Cheers  