### PR TITLE
refs & slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [2.2.1] - 2025-03-26
 ### Fixed
-- macOS alias check turned off till fixed 
-
+- macOS alias check turned off till fixed
+- use `&str` && `&[]` more wide
 
 ## [2.2.0] - 2025-03-25
 ### Added / Fixed
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 - Added custom error type
 - Made template search for macOS retina displays more robust. Now 2 variants of template are stored, the provided one and resized one. The search is done for both of them. The reason for this is, it cannot be known if user is providing template image which he got as a snip which needs to be resized, or from a (for instance) downloaded image which does not require resize
 - updated to latest versions of dependencies
-- Fix: find_image_and_move_mouse now returns vec of all found locations instead of just top location 
+- Fix: find_image_and_move_mouse now returns vec of all found locations instead of just top location
 - Fix: README code examples fixed
 - Fix: check for out of bounds on windows mouse move fixed
 - imgtools::convert_image_to_bw was renamed to convert_rgba_to_bw
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 
 
 
- 
+
 
 ## [2.1.1] - 2025-03.16
 ### Fixed
@@ -54,11 +54,11 @@ All notable changes to this project will be documented in this file.
 ## [2.0.1] - 2025-03.14
 ### Fixed
 - Fixed readme code examples
-- fixed Segmented normalized cross correlation doing false matches.  
+- fixed Segmented normalized cross correlation doing false matches.
 
 ## [2.0.0] - 2025-03.10
 ### Added/Fixed
-- complete rework of the code which will not be compatible with old versions. 
+- complete rework of the code which will not be compatible with old versions.
 - introduced graceful exits, except for some situations like not having x11 activated on linux
 - most of methods return Result<> now.
 
@@ -77,7 +77,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.3.1] - 2024-08.01
 ### Added
--small optimization to template prepare 
+-small optimization to template prepare
 
 ## [0.3.0] - 2024-07.27
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.2.2] - 2025-03-27
+### Fixed
+- use `&str` && `&[]` more wide
+
 ## [2.2.1] - 2025-03-26
 ### Fixed
 - macOS alias check turned off till fixed
-- use `&str` && `&[]` more wide
+
 
 ## [2.2.0] - 2025-03-25
 ### Added / Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustautogui"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2021"
 description = "rustautogui is a GUI automation module used to control the mouse and keyboard"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # RustAutoGUI
 
-RustAutoGUI crate, made after Al Sweigarts library PyAutoG for python. 
+RustAutoGUI crate, made after Al Sweigarts library PyAutoG for python.
 
-RustAutoGUI allows you to control the mouse and keyboard to automate interactions with other applications. 
+RustAutoGUI allows you to control the mouse and keyboard to automate interactions with other applications.
 The crate works on Windows, Linux and Macos.
 
 Main functions:
@@ -27,13 +27,13 @@ OpenCV requires complex dependencies and a lengthy setup process in Rust. To kee
 
 ### Segmented template matching algorithm
 
-Since version 1.0.0, RustAutoGUI crate includes another variation of template matching algorithm using Segmented Normalized Cross-Correlation. 
+Since version 1.0.0, RustAutoGUI crate includes another variation of template matching algorithm using Segmented Normalized Cross-Correlation.
 More information: https://arxiv.org/pdf/2502.01286
 
 
 ## Installation
 
-Either run 
+Either run
 `cargo add rustautogui`
 
 or add the crate in your Cargo.toml:
@@ -54,7 +54,7 @@ For macOS: grant necessary permissions in your settings.
 
 Since version 2.2.0, RustAutoGUI supports loading multiple images in memory and searching them. It also allows loading images from memory instead of only from disk.
 
-Loading an image does certain precalculations required for the template matching process, which allows faster execution of the process itself requiring less computations. 
+Loading an image does certain precalculations required for the template matching process, which allows faster execution of the process itself requiring less computations.
 
 ### Import and Initialize RustAutoGui
 ```rust
@@ -68,18 +68,18 @@ let mut rustautogui = rustautogui::RustAutoGui::new(false); // arg: debug
 From file, same as load_and_prepare_template which will be deprecated
 ```rust
 rustautogui.prepare_template_from_file( // returns Result<(), String>
-   "template.png", // template_path: &str path to the image file on disk 
+   "template.png", // template_path: &str path to the image file on disk
    Some((0,0,1000,1000)), // region: Option<(u32, u32, u32, u32)>  region of monitor to search (x, y, width, height)
    rustautogui::MatchMode::Segmented, // match_mode: rustautogui::MatchMode search mode (Segmented or FFT)
    Some(3000) // max_segments: Option<u32> max segments for Segmented match mode. Can be set to None to automatically calculate
-).unwrap(); 
+).unwrap();
 ```
 From ImageBuffer<RGB/RGBA/Luma<u8>>
 ```rust
 rustautogui.prepare_template_from_imagebuffer( // returns Result<(), String>
    img_buffer, // image:  ImageBuffer<P, Vec<T>> -- Accepts RGB/RGBA/Luma(black and white)
    None,  // region: Option<(u32, u32, u32, u32)> searches whole screen when None
-   rustautogui::MatchMode::FFT, // match_mode: rustautogui::MatchMode search mode (Segmented or FFT)  
+   rustautogui::MatchMode::FFT, // match_mode: rustautogui::MatchMode search mode (Segmented or FFT)
    None, // max_segments: Option<u32> no need for segments when doing FFT search
 ).unwrap();
 ```
@@ -87,21 +87,21 @@ From raw bytes of encoded image
 ```rust
 rustautogui.prepare_template_from_raw_encoded( // returns Result<(), String>
    img_raw // img_raw:  &[u8] - encoded raw bytes
-   None,  // region: Option<(u32, u32, u32, u32)> 
-   rustautogui::MatchMode::FFT, // match_mode: rustautogui::MatchMode search mode (Segmented or FFT)  
-   None, // max_segments: Option<u32> 
+   None,  // region: Option<(u32, u32, u32, u32)>
+   rustautogui::MatchMode::FFT, // match_mode: rustautogui::MatchMode search mode (Segmented or FFT)
+   None, // max_segments: Option<u32>
 ).unwrap();
 
 ```
 
 Changing template settings
 
- 
+
 ```rust
 // change template matching settings, if template is already loaded (does not work for stored images with alias)
 rustautogui.change_prepared_settings(
    Some((0,0,1000,1000)), //region: Option<(u32, u32, u32, u32)>
-   rustautogui::MatchMode::Segmented, // match_mode: rustautogui::MatchMode search mode (Segmented or FFT)  
+   rustautogui::MatchMode::Segmented, // match_mode: rustautogui::MatchMode search mode (Segmented or FFT)
    None // max_segments: Option<u32>
 );
 
@@ -126,36 +126,36 @@ If you're looking to maximize speed, your template and region of search should b
 
 ## Loading multiple images into memory
 
-Functions  work the same as single image loads, with additional parameter of alias for the image. 
+Functions  work the same as single image loads, with additional parameter of alias for the image.
 
 Load from file
 ```rust
 rustautogui.store_template_from_file( // returns Result<(), String>
-   "template.png", // template_path: &str path to the image file on disk 
+   "template.png", // template_path: &str path to the image file on disk
    Some((0,0,1000,1000)), // region: Option<(u32, u32, u32, u32)>  region of monitor to search (x, y, width, height)
    rustautogui::MatchMode::Segmented, // match_mode: rustautogui::MatchMode search mode (Segmented or FFT)
    Some(3000), // max_segments: Option<u32> max segments for Segmented match mode. Can be set to None to automatically calculate
-   "button_image".to_string() // alias: String. Keyword used to select which image to search for
-).unwrap(); 
+   "button_image" // alias: &str. Keyword used to select which image to search for
+).unwrap();
 ```
 Load from Imagebuffer
 ```rust
 rustautogui.store_template_from_imagebuffer( // returns Result<(), String>
    img_buffer, // image:  ImageBuffer<P, Vec<T>> -- Accepts RGB/RGBA/Luma(black and white)
-   None,  // region: Option<(u32, u32, u32, u32)> 
-   rustautogui::MatchMode::Segmented, // match_mode: rustautogui::MatchMode search mode (Segmented or FFT)  
-   None, // max_segments: Option<u32> 
-   "button_image".to_string() // alias: String. Keyword used to select which image to search for
+   None,  // region: Option<(u32, u32, u32, u32)>
+   rustautogui::MatchMode::Segmented, // match_mode: rustautogui::MatchMode search mode (Segmented or FFT)
+   None, // max_segments: Option<u32>
+   "button_image" // alias: &str. Keyword used to select which image to search for
 ).unwrap();
 ```
 Load from encoded raw bytes
 ```rust
 rustautogui.store_template_from_raw_encoded( // returns Result<(), String>
    img_raw // img_raw:  &[u8] encoded raw bytes
-   None,  // region: Option<(u32, u32, u32, u32)> 
-   rustautogui::MatchMode::Segmented, // match_mode: rustautogui::MatchMode search mode (Segmented or FFT)  
-   None, // max_segments: Option<u32> 
-   "button_image".to_string() // alias: String. Keyword used to select which image to search for
+   None,  // region: Option<(u32, u32, u32, u32)>
+   rustautogui::MatchMode::Segmented, // match_mode: rustautogui::MatchMode search mode (Segmented or FFT)
+   None, // max_segments: Option<u32>
+   "button_image" // alias: &str. Keyword used to select which image to search for
 ).unwrap();
 
 ```
@@ -187,7 +187,7 @@ rustautogui
 
 ```rust
 rustautogui
-        .loop_find_image_on_screen_and_move_mouse(0.95, 1.0, 15) // args: precision, moving_time and timeout 
+        .loop_find_image_on_screen_and_move_mouse(0.95, 1.0, 15) // args: precision, moving_time and timeout
         .unwrap();
 ```
 
@@ -197,39 +197,39 @@ Again, functions are the same, just having alias argument
 
 ```rust
 rustautogui
-      .find_stored_image_on_screen(0.9,  &"test2".to_string()) // precision, alias
+      .find_stored_image_on_screen(0.9,  "test2") // precision, alias
       .unwrap();
 ```
 With mouse movement to location
 ```rust
 rustautogui
-      .find_stored_image_on_screen_and_move_mouse(0.9, 1.0, &"test2".to_string()) // precision, moving_time, alias (&String)
+      .find_stored_image_on_screen_and_move_mouse(0.9, 1.0, "test2") // precision, moving_time, alias (&str)
       .unwrap();
 ```
-Loop search 
+Loop search
 <br><strong> Warning: timeout of 0 initiates infinite loop</strong>
 
 ```rust
 rustautogui
-        .loop_find_stored_image_on_screen(0.95, 15, &"stars".to_string()) // precision, timeout, alias
+        .loop_find_stored_image_on_screen(0.95, 15, "stars") // precision, timeout, alias
         .unwrap();
 ```
 
 ```rust
 rustautogui
-        .loop_find_stored_image_on_screen_and_move_mouse(0.95, 1.0, 15, &"stars".to_string()) // precision, moving_time, timeout, alias
+        .loop_find_stored_image_on_screen_and_move_mouse(0.95, 1.0, 15, "stars") // precision, moving_time, timeout, alias
         .unwrap();
 ```
 
 ### MacOS retina display issues:
-Macos retina display functions by digitally doubling the amount of displayed pixels. The original screen size registered by OS is, 
+Macos retina display functions by digitally doubling the amount of displayed pixels. The original screen size registered by OS is,
 for instance, 1400x800. Retina display doubles it to 2800x1600. If a user provides a screengrab, the image will be saved with doubled the amount
 of pixels, where it then fails to match template since screen provided by OS api is not doubled. It can also not be known if user is providing template from a screen grab, or an image thats coming from some other source. For that reason, every template is saved in its original format,
-and also resized by half. The template search first searches for resized template, and if it fails then it tries with original. For that reason, users on macOS will experience slower search times than users on other operating systems. 
+and also resized by half. The template search first searches for resized template, and if it fails then it tries with original. For that reason, users on macOS will experience slower search times than users on other operating systems.
 
 
 ## General functions
-Debug mode prints out number of segments in segmented picture, times taken for algorithm run and it saves segmented images. It also creates debug folder in code root, where the images are saved. 
+Debug mode prints out number of segments in segmented picture, times taken for algorithm run and it saves segmented images. It also creates debug folder in code root, where the images are saved.
 
 Warnings give useful information which shouldn't pop up frequently
 ```rust
@@ -239,7 +239,7 @@ rustautogui.set_suppress_warning(true); // turn off warnings
 rustautogui.save_screenshot("test.png").unwrap(); //saves screen screenshot
 ```
 
-## Mouse functions 
+## Mouse functions
 ```rust
 rustautogui.left_click().unwrap(); // left mouse click
 rustautogui.right_click().unwrap(); // right mouse click
@@ -250,7 +250,7 @@ rustautogui.scroll_down().unwrap();
 rustautogui.scroll_left().unwrap();
 rustautogui.scroll_right().unwrap();
 rustautogui.move_mouse_to_pos(1920, 1080, 1.0).unwrap(); // args: x, y, moving_time. Moves mouse to position for certain time
-rustautogui.drag_mouse(500, 500, 1.0).unwrap(); // executes left click down, move mouse_to_pos x, y location, left click up. 
+rustautogui.drag_mouse(500, 500, 1.0).unwrap(); // executes left click down, move mouse_to_pos x, y location, left click up.
 //note: use moving time > 0.2, or even higher, depending on distance. Especially important for macOS
 ```
 
@@ -267,13 +267,13 @@ fn main() {
 Currently, only US keyboard is implemented. If you have different layout active, lots of characters will not work correctly
 ```rust
 rustautogui.keyboard_input("test!@#24").unwrap(); // input string, or better say, do the sequence of key presses
-rustautogui.keyboard_command("backspace").unwrap(); // press a keyboard button 
+rustautogui.keyboard_command("backspace").unwrap(); // press a keyboard button
 rustautogui.keyboard_multi_key("shift", "control", Some("t")).unwrap(); // Executed multiple key press at same time. third argument is optional
 ```
 
 
-For all the keyboard commands check Keyboard_commands.md, a table of possible keyboard inputs/commands for each OS. If you 
-find some keyboard commands missing that you need, please open an issue in order to get it added in next versions. 
+For all the keyboard commands check Keyboard_commands.md, a table of possible keyboard inputs/commands for each OS. If you
+find some keyboard commands missing that you need, please open an issue in order to get it added in next versions.
 
 
 
@@ -290,12 +290,12 @@ Windows CMD:
    set RUSTAUTOGUI_SUPPRESS_WARNINGS=1       #to turn off warnings
    set RUSTAUTOGUI_SUPPRESS_WARNINGS=0       #to activate warnings
 ```
-Linux/MacOS: 
+Linux/MacOS:
 ```
    export RUSTAUTOGUI_SUPPRESS_WARNINGS=1    #to turn off warnings
    export RUSTAUTOGUI_SUPPRESS_WARNINGS=0    #to activate warnings
 ```
-or in code: 
+or in code:
 
 ```rust
 let mut rustautogui = RustAutoGui::new(false).unwrap();
@@ -311,17 +311,17 @@ rustautogui.set_suppress_warnings(true);
 - on macOS, it uses core-graphics crate
 
 
-## Major changes: 
+## Major changes:
 
 - 1.0.0 - introduces segmented match mode
 - 2.0.0 - removed most of panics and crashes
-- 2.1.0 - fixed on keyboard, some methods arguments / returns changed and will cause code breaking. 
+- 2.1.0 - fixed on keyboard, some methods arguments / returns changed and will cause code breaking.
 - 2.2.0 - loading multiple images, loading images from memory
 
 
 
 ## Additional notes
-Data stored in prepared template data 
+Data stored in prepared template data
 ```rust
 pub enum PreparedData {
     Segmented(

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Either run
 
 or add the crate in your Cargo.toml:
 
-`rustautogui = "2.2.1"`
+`rustautogui = "2.2.2"`
 
 For Linux additionally run:
 

--- a/examples/open_github_page.rs
+++ b/examples/open_github_page.rs
@@ -22,7 +22,7 @@ fn main() {
             )),
             rustautogui::MatchMode::Segmented,
             None,
-            "stars".to_string(),
+            "stars",
         )
         .unwrap();
 
@@ -76,7 +76,7 @@ fn main() {
 
     // loop till image of star is found or timeout of 15 seconds is hit
     rustautogui
-        .loop_find_stored_image_on_screen_and_move_mouse(0.95, 1.0, 15, &"stars".to_string())
+        .loop_find_stored_image_on_screen_and_move_mouse(0.95, 1.0, 15, "stars")
         .unwrap();
 
     thread::sleep(time::Duration::from_millis(500));

--- a/src/imgtools/mod.rs
+++ b/src/imgtools/mod.rs
@@ -46,7 +46,7 @@ where
 
 pub fn convert_t_imgbuffer_to_luma<P, T>(
     image: &ImageBuffer<P, Vec<T>>,
-    color_scheme: &u32,
+    color_scheme: u32,
 ) -> Result<ImageBuffer<Luma<u8>, Vec<u8>>, AutoGuiError>
 where
     P: Pixel<Subpixel = T> + 'static,

--- a/src/keyboard/linux/mod.rs
+++ b/src/keyboard/linux/mod.rs
@@ -113,7 +113,7 @@ impl Keyboard {
     }
 
     /// grabs the value from structs keymap, then converts String to Keysim, and then keysim to Keycode.
-    unsafe fn get_keycode(&self, key: &String) -> Result<(u32, &bool), AutoGuiError> {
+    unsafe fn get_keycode(&self, key: &str) -> Result<(u32, &bool), AutoGuiError> {
         let (value, shifted) = get_keymap_key(self, key)?;
 
         let mut keysym_to_keycode = HashMap::new();
@@ -156,7 +156,7 @@ impl Keyboard {
     }
 
     /// similar to send char, but can be string such as return, escape etc
-    pub fn send_command(&self, key: &String) -> Result<(), AutoGuiError> {
+    pub fn send_command(&self, key: &str) -> Result<(), AutoGuiError> {
         unsafe {
             let keycode = self.get_keycode(key)?;
             self.send_key(keycode.0);
@@ -166,8 +166,8 @@ impl Keyboard {
 
     pub fn send_multi_key(
         &self,
-        key_1: &String,
-        key_2: &String,
+        key_1: &str,
+        key_2: &str,
         key_3: Option<String>,
     ) -> Result<(), AutoGuiError> {
         unsafe {

--- a/src/keyboard/macos/mod.rs
+++ b/src/keyboard/macos/mod.rs
@@ -73,7 +73,7 @@ impl Keyboard {
         Ok(())
     }
 
-    pub fn send_command(&self, key: &String) -> Result<(), AutoGuiError> {
+    pub fn send_command(&self, key: &str) -> Result<(), AutoGuiError> {
         let value = crate::keyboard::get_keymap_key(self, key)?;
 
         self.send_key(value.0)?;
@@ -82,8 +82,8 @@ impl Keyboard {
 
     pub fn send_multi_key(
         &self,
-        key_1: &String,
-        key_2: &String,
+        key_1: &str,
+        key_2: &str,
         key_3: Option<String>,
     ) -> Result<(), AutoGuiError> {
         let value1 = self

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -18,7 +18,7 @@ pub mod macos;
 use macos::Keyboard;
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-fn get_keymap_key<'a>(target: &'a Keyboard, key: &String) -> Result<&'a (u16, bool), AutoGuiError> {
+fn get_keymap_key<'a>(target: &'a Keyboard, key: &str) -> Result<&'a (u16, bool), AutoGuiError> {
     let values = target
         .keymap
         .get(key)
@@ -30,10 +30,7 @@ fn get_keymap_key<'a>(target: &'a Keyboard, key: &String) -> Result<&'a (u16, bo
 }
 
 #[cfg(target_os = "linux")]
-fn get_keymap_key<'a>(
-    target: &'a Keyboard,
-    key: &String,
-) -> Result<&'a (String, bool), AutoGuiError> {
+fn get_keymap_key<'a>(target: &'a Keyboard, key: &str) -> Result<&'a (String, bool), AutoGuiError> {
     let values = target
         .keymap
         .get(key)

--- a/src/keyboard/windows/mod.rs
+++ b/src/keyboard/windows/mod.rs
@@ -112,7 +112,7 @@ impl Keyboard {
     }
 
     /// Function used when sending commands like "return" or "escape"
-    pub fn send_command(&self, key: &String) -> Result<(), AutoGuiError> {
+    pub fn send_command(&self, key: &str) -> Result<(), AutoGuiError> {
         let (value, _) = get_keymap_key(&self, key)?;
         Keyboard::send_key(value);
         Ok(())
@@ -120,8 +120,8 @@ impl Keyboard {
 
     pub fn send_multi_key(
         &self,
-        key_1: &String,
-        key_2: &String,
+        key_1: &str,
+        key_2: &str,
         key_3: Option<String>,
     ) -> Result<(), AutoGuiError> {
         let (value_1, _) = get_keymap_key(&self, key_1)?;

--- a/src/normalized_x_corr/fft_ncc.rs
+++ b/src/normalized_x_corr/fft_ncc.rs
@@ -14,7 +14,7 @@ use super::{compute_integral_images, sum_region};
 
 pub fn fft_ncc(
     image: &ImageBuffer<Luma<u8>, Vec<u8>>,
-    precision: &f32,
+    precision: f32,
     prepared_data: &(Vec<Complex<f32>>, f32, u32, u32, u32),
 ) -> Vec<(u32, u32, f64)> {
     // retreive all precalculated template data, most importantly template with already fft and conjugation calculated
@@ -88,18 +88,18 @@ pub fn fft_ncc(
             let corr = fft_correlation_calculation(
                 &image_integral,
                 &squared_image_integral,
-                &template_width,
-                &template_height,
-                &template_sum_squared_deviations,
-                &x,
-                &y,
-                &padded_size,
+                *template_width,
+                *template_height,
+                *template_sum_squared_deviations,
+                x,
+                y,
+                *padded_size,
                 &fft_result,
             );
 
             (x, y, corr)
         })
-        .filter(|&(_, _, corr)| corr > *precision as f64)
+        .filter(|&(_, _, corr)| corr > precision as f64)
         .collect();
     found_points.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap());
 
@@ -108,38 +108,38 @@ pub fn fft_ncc(
 
 #[allow(dead_code)]
 fn fft_correlation_calculation(
-    image_integral: &Vec<Vec<u64>>,
-    squared_image_integral: &Vec<Vec<u64>>,
-    template_width: &u32,
-    template_height: &u32,
-    template_sum_squared_deviations: &f32,
-    x: &u32, // big image x value
-    y: &u32, // big image y value,
-    padded_size: &u32,
-    fft_result: &Vec<Complex<f32>>,
+    image_integral: &[Vec<u64>],
+    squared_image_integral: &[Vec<u64>],
+    template_width: u32,
+    template_height: u32,
+    template_sum_squared_deviations: f32,
+    x: u32, // big image x value
+    y: u32, // big image y value,
+    padded_size: u32,
+    fft_result: &[Complex<f32>],
 ) -> f64 {
     /// Function for calculation of correlation at each pixel position
     ////////// denominator calculation
-    let sum_image: u64 = sum_region(image_integral, *x, *y, *template_width, *template_height);
+    let sum_image: u64 = sum_region(image_integral, x, y, template_width, template_height);
 
     let sum_squared_image: u64 = sum_region(
         squared_image_integral,
-        *x,
-        *y,
-        *template_width,
-        *template_height,
+        x,
+        y,
+        template_width,
+        template_height,
     );
     let image_sum_squared_deviations = sum_squared_image as f64
         - (sum_image as f64).powi(2) / (template_height * template_width) as f64; //@audit check template_height*template_width!=0
     let denominator =
-        (image_sum_squared_deviations * *template_sum_squared_deviations as f64).sqrt();
+        (image_sum_squared_deviations * template_sum_squared_deviations as f64).sqrt();
 
     /////////////// NOMINATOR CALCULATION
 
     // fft result is calculated invert of whole image and template that were padded and zero valued
     // each pixel position shows value for that template position
-    let numerator_value = fft_result[(y * padded_size) as usize + *x as usize].re
-        / (padded_size * padded_size) as f32; //@audit guess the padded_size is always non zero but could be checked
+    let numerator_value =
+        fft_result[(y * padded_size) as usize + x as usize].re / (padded_size * padded_size) as f32; //@audit guess the padded_size is always non zero but could be checked
     let mut corr = numerator_value as f64 / denominator;
 
     if corr > 2.0 {
@@ -150,14 +150,14 @@ fn fft_correlation_calculation(
 
 pub fn prepare_template_picture(
     template: &ImageBuffer<Luma<u8>, Vec<u8>>,
-    image_width: &u32,
-    image_height: &u32,
+    image_width: u32,
+    image_height: u32,
 ) -> (Vec<Complex<f32>>, f32, u32, u32, u32) {
     /// precalculate all the neccessary data so its not slowing down main process
     /// returning template in frequency domain, with calculated conjugate
     let (template_width, template_height) = template.dimensions();
-    let padded_width = (*image_width).next_power_of_two();
-    let padded_height = (*image_height).next_power_of_two();
+    let padded_width = image_width.next_power_of_two();
+    let padded_height = image_height.next_power_of_two();
     let padded_size = max(padded_width, padded_height);
 
     let mut sum_template = 0.0;

--- a/src/normalized_x_corr/mod.rs
+++ b/src/normalized_x_corr/mod.rs
@@ -2,7 +2,7 @@ pub mod fast_segment_x_corr;
 pub mod fft_ncc;
 pub mod slow_ncc;
 
-fn compute_integral_image(image: &Vec<Vec<u8>>) -> Vec<Vec<u64>> {
+fn compute_integral_image(image: &[Vec<u8>]) -> Vec<Vec<u64>> {
     /*
     Function that takes an image as input and computes an integral table (sum table).
     Table is calculated in a way : f(x,y) = sum where f(x1<=x, y1<=y), meaning it always
@@ -53,7 +53,7 @@ fn compute_integral_image(image: &Vec<Vec<u8>>) -> Vec<Vec<u64>> {
     integral_image
 }
 
-fn compute_squared_integral_image(image: &Vec<Vec<u8>>) -> Vec<Vec<u64>> {
+fn compute_squared_integral_image(image: &[Vec<u8>]) -> Vec<Vec<u64>> {
     /*
     Same as compute_integral_image, except we always take squared value of pixel f(x,y).
     */
@@ -86,7 +86,7 @@ fn compute_squared_integral_image(image: &Vec<Vec<u8>>) -> Vec<Vec<u64>> {
 }
 
 /// Compute both normal and squared integral image
-fn compute_integral_images(image: &Vec<Vec<u8>>) -> (Vec<Vec<u64>>, Vec<Vec<u64>>) {
+fn compute_integral_images(image: &[Vec<u8>]) -> (Vec<Vec<u64>>, Vec<Vec<u64>>) {
     let height = image.len() as u32;
     let width = if height > 0 { image[0].len() as u32 } else { 0 };
     let mut integral_image = vec![vec![0u64; width as usize]; height as usize];
@@ -127,7 +127,7 @@ fn compute_integral_images(image: &Vec<Vec<u8>>) -> (Vec<Vec<u64>>, Vec<Vec<u64>
     (integral_image, squared_integral_image)
 }
 
-fn sum_region(integral_image: &Vec<Vec<u64>>, x: u32, y: u32, width: u32, height: u32) -> u64 {
+fn sum_region(integral_image: &[Vec<u64>], x: u32, y: u32, width: u32, height: u32) -> u64 {
     /*
     Used to calculate sum region of an integral image. Bottom right pixel will have summed up value of everything above and left.
     In order to get exact sum value of subregion of the image, we take that sum from bottom right,

--- a/src/normalized_x_corr/slow_ncc.rs
+++ b/src/normalized_x_corr/slow_ncc.rs
@@ -84,8 +84,8 @@ pub fn slow_ncc_template_match(
 
 fn calculate_corr_value(
     image: &ImageBuffer<Luma<u8>, Vec<u8>>,
-    image_integral: &Vec<Vec<u64>>,
-    squared_image_integral: &Vec<Vec<u64>>,
+    image_integral: &[Vec<u64>],
+    squared_image_integral: &[Vec<u64>],
     template: &ImageBuffer<Luma<u8>, Vec<u8>>,
     template_width: u32,
     template_height: u32,

--- a/src/screen/macos/mod.rs
+++ b/src/screen/macos/mod.rs
@@ -38,14 +38,14 @@ impl Screen {
             let scaling_factor_x = image_width as f64 / screen_width as f64;
             let scaling_factor_y = image_height as f64 / screen_height as f64;
             Ok(Self {
-                screen_height: screen_height,
-                screen_width: screen_width,
+                screen_height,
+                screen_width,
                 screen_region_height: 0,
                 screen_region_width: 0,
                 pixel_data: vec![0u8; (screen_width * screen_height * 4) as usize],
                 display: main_display,
-                scaling_factor_x: scaling_factor_x,
-                scaling_factor_y: scaling_factor_y,
+                scaling_factor_x,
+                scaling_factor_y,
             })
         }
     }


### PR DESCRIPTION
Avoid `&String` or `&Vec` if it is not needed. `&str` and `&[]` almost always is better.

Primitive copy types like `u32`, `f32`, etc. is more efficient to pass by value then by reference.
`&u32` makes no sense in functions. Only `u32` and `&mut u32`.