### PR TITLE
Lower macOS scrolling resolution

### DIFF
--- a/src/core/mouse/macos/mod.rs
+++ b/src/core/mouse/macos/mod.rs
@@ -282,9 +282,9 @@ impl Mouse {
     pub fn scroll(direction: MouseScroll, intensity: u32) -> Result<(), AutoGuiError> {
         let delta = match direction {
             MouseScroll::UP => (intensity as i32, 0),
-            MouseScroll::DOWN => (-intensity as i32, 0),
+            MouseScroll::DOWN => (-1 * intensity as i32, 0),
             MouseScroll::LEFT => (0, intensity as i32),
-            MouseScroll::RIGHT => (0, -intensity as i32),
+            MouseScroll::RIGHT => (0, -1 * intensity as i32),
         };
         let cg_event_source =
             CGEventSource::new(CGEventSourceStateID::HIDSystemState).map_err(|_| {

--- a/src/core/mouse/macos/mod.rs
+++ b/src/core/mouse/macos/mod.rs
@@ -281,10 +281,10 @@ impl Mouse {
 
     pub fn scroll(direction: MouseScroll, intensity: u32) -> Result<(), AutoGuiError> {
         let delta = match direction {
-            MouseScroll::UP => (10 * intensity as i32, 0),
-            MouseScroll::DOWN => (-10 * intensity as i32, 0),
-            MouseScroll::LEFT => (0, 10 * intensity as i32),
-            MouseScroll::RIGHT => (0, -10 * intensity as i32),
+            MouseScroll::UP => (intensity as i32, 0),
+            MouseScroll::DOWN => (-intensity as i32, 0),
+            MouseScroll::LEFT => (0, intensity as i32),
+            MouseScroll::RIGHT => (0, -intensity as i32),
         };
         let cg_event_source =
             CGEventSource::new(CGEventSourceStateID::HIDSystemState).map_err(|_| {


### PR DESCRIPTION
The maximum value of the intensity parameter is already large enough to satisfy any user who needs fast mouse scrolling, however it is not small enough to meet the demand for slower, more delicate scrolling. We should give the right to choose to the user, so we request to remove the 10x magnification for intensity.