### PR TITLE
Silence logging match mode outside of debug

### DIFF
--- a/src/rustautogui_impl/template_match_impl/find_img_impl.rs
+++ b/src/rustautogui_impl/template_match_impl/find_img_impl.rs
@@ -345,7 +345,9 @@ impl crate::RustAutoGui {
         let match_mode = self.template_data.match_mode.clone().ok_or(ImageProcessingError::new("No template chosen and no template data prepared. Please run load_and_prepare_template before searching image on screen"))?;
         let found_locations: Vec<(u32, u32, f32)> = match match_mode {
             MatchMode::FFT => {
-                println!("Running FFT mode");
+                if self.debug {
+                    println!("Running FFT mode");
+                }
                 let data = match &self.template_data.prepared_data {
                     PreparedData::FFT(data) => data,
                     _ => Err(ImageProcessingError::new(
@@ -360,7 +362,9 @@ impl crate::RustAutoGui {
                     .collect()
             }
             MatchMode::Segmented => {
-                println!("Running Segmented mode");
+                if self.debug {
+                    println!("Running Segmented mode");
+                }
                 let data = match &self.template_data.prepared_data {
                     PreparedData::Segmented(data) => data,
                     _ => Err(ImageProcessingError::new(


### PR DESCRIPTION
Hello, I would like the matching to not print to std output when debug is not enabled. 

I thought that it was okay to make this change, because there's logging of the positions of detected images already being behind the debug field.
