### PR TITLE
Port windows bindings to the "windows" crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [UNRELEASED]
+### Changed
+- Port windows bindings to the "windows" crate. Was previously using the "winapi" crate.
+
 ## [2.5.0] - 2025-04-27
 ### Added 
 - Added **OpenCL** implementation of the algorithm. Now you can run the template matching process of GPU to achieve better performance. Two variants of algorithm included

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ core-graphics = {version = "0.23.2", features = ["highsierra"]}
 
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winuser", "windef"] }
+windows = { version = ">=0.59, <=0.62.2", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_Graphics_Gdi"] }
+windows-result = ">= 0.4.0"
 
 
 [features]

--- a/src/core/keyboard/windows/mod.rs
+++ b/src/core/keyboard/windows/mod.rs
@@ -1,11 +1,9 @@
 use crate::core::keyboard::get_keymap_key;
 use crate::errors::AutoGuiError;
 use std::{collections::HashMap, mem::size_of, thread::sleep, time::Duration};
-use winapi::um::wingdi::SRCAND;
-use winapi::um::winuser::{MapVirtualKeyW, MAPVK_VK_TO_VSC};
-use winapi::um::winuser::{
-    SendInput, INPUT, INPUT_KEYBOARD, KEYEVENTF_KEYUP, KEYEVENTF_SCANCODE, VK_CONTROL, VK_MENU,
-    VK_SHIFT,
+use windows::Win32::UI::Input::KeyboardAndMouse::{
+    MapVirtualKeyW, SendInput, INPUT, INPUT_KEYBOARD, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
+    KEYEVENTF_SCANCODE, MAPVK_VK_TO_VSC, VIRTUAL_KEY, VK_CONTROL, VK_MENU, VK_SHIFT,
 };
 
 /// main struct for interacting with keyboard. Keymap is generated upon intialization.
@@ -22,20 +20,17 @@ impl Keyboard {
 
     unsafe fn press_key(scan_code: &u16) {
         let mut input: INPUT = std::mem::zeroed();
-        input.type_ = INPUT_KEYBOARD;
+        input.r#type = INPUT_KEYBOARD;
         {
             let scan_code = *scan_code;
-            let ki = input.u.ki_mut();
-            if scan_code == VK_SHIFT as u16
-                || scan_code == VK_CONTROL as u16
-                || scan_code == VK_MENU as u16
-            {
-                ki.wVk = scan_code; // Use virtual key code for Shift, Control, and Alt
+            let ki = &mut input.Anonymous.ki;
+            if scan_code == VK_SHIFT.0 || scan_code == VK_CONTROL.0 || scan_code == VK_MENU.0 {
+                ki.wVk = VIRTUAL_KEY(scan_code); // Use virtual key code for Shift, Control, and Alt
                 ki.wScan = 0;
-                ki.dwFlags = 0; // No KEYEVENTF_SCANCODE flag for virtual key
+                ki.dwFlags = KEYBD_EVENT_FLAGS(0); // No KEYEVENTF_SCANCODE flag for virtual key
             } else {
                 let scan_code = MapVirtualKeyW(scan_code as u32, MAPVK_VK_TO_VSC) as u16;
-                ki.wVk = 0;
+                ki.wVk = VIRTUAL_KEY(0);
                 ki.wScan = scan_code;
                 ki.dwFlags = KEYEVENTF_SCANCODE;
             }
@@ -44,25 +39,22 @@ impl Keyboard {
         }
 
         // Send key press
-        SendInput(1, &mut input, size_of::<INPUT>() as i32);
+        SendInput(&[input], size_of::<INPUT>() as i32);
     }
 
     unsafe fn release_key(scan_code: &u16) {
         let mut input: INPUT = std::mem::zeroed();
-        input.type_ = INPUT_KEYBOARD;
+        input.r#type = INPUT_KEYBOARD;
         {
             let scan_code = *scan_code;
-            let ki = input.u.ki_mut();
-            if scan_code == VK_SHIFT as u16
-                || scan_code == VK_CONTROL as u16
-                || scan_code == VK_MENU as u16
-            {
-                ki.wVk = scan_code; // Use virtual key code for Shift, Control, and Alt
+            let ki = &mut input.Anonymous.ki;
+            if scan_code == VK_SHIFT.0 || scan_code == VK_CONTROL.0 || scan_code == VK_MENU.0 {
+                ki.wVk = VIRTUAL_KEY(scan_code); // Use virtual key code for Shift, Control, and Alt
                 ki.wScan = 0;
                 ki.dwFlags = KEYEVENTF_KEYUP; // No KEYEVENTF_SCANCODE flag for virtual key
             } else {
                 let scan_code = MapVirtualKeyW(scan_code as u32, MAPVK_VK_TO_VSC) as u16;
-                ki.wVk = 0;
+                ki.wVk = VIRTUAL_KEY(0);
                 ki.wScan = scan_code;
                 ki.dwFlags = KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP;
             }
@@ -71,7 +63,7 @@ impl Keyboard {
         }
 
         // Release key
-        SendInput(1, &mut input, size_of::<INPUT>() as i32);
+        SendInput(&[input], size_of::<INPUT>() as i32);
     }
 
     pub fn key_down(&self, key: &str) -> Result<(), AutoGuiError> {

--- a/src/core/mouse/mouse_position.rs
+++ b/src/core/mouse/mouse_position.rs
@@ -69,7 +69,7 @@ pub fn print_mouse_position() -> Result<(), AutoGuiError> {
     #[cfg(target_os = "windows")]
     {
         loop {
-            let (x, y) = Mouse::get_mouse_position();
+            let (x, y) = Mouse::get_mouse_position()?;
             println!("{x}, {y}");
             sleep(Duration::from_millis(20));
         }

--- a/src/core/mouse/windows/mod.rs
+++ b/src/core/mouse/windows/mod.rs
@@ -1,12 +1,15 @@
 use crate::core::mouse::{MouseClick, MouseScroll};
+use crate::errors::AutoGuiError;
 use std::mem::{size_of, zeroed};
 use std::{thread, time, time::Instant};
-use winapi::shared::windef::POINT;
-use winapi::um::winuser::{
-    SendInput, SetCursorPos, INPUT, INPUT_MOUSE, MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN,
-    MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP, MOUSEEVENTF_RIGHTDOWN,
-    MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_WHEEL,
+use windows::Win32::Foundation::POINT;
+use windows::Win32::UI::Input::KeyboardAndMouse::{
+    SendInput, INPUT, INPUT_MOUSE, MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP,
+    MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP, MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP,
+    MOUSEEVENTF_WHEEL,
 };
+use windows::Win32::UI::WindowsAndMessaging::{GetCursorPos, SetCursorPos};
+
 #[derive(Debug)]
 pub struct Mouse {}
 impl Mouse {
@@ -16,17 +19,16 @@ impl Mouse {
     }
 
     /// moves mouse to x, y pixel coordinate on screen
-    pub fn move_mouse_to_pos(x: i32, y: i32, moving_time: f32) {
+    pub fn move_mouse_to_pos(x: i32, y: i32, moving_time: f32) -> Result<(), AutoGuiError> {
         // if no moving time, then instant move is executed
         unsafe {
             if moving_time <= 0.0 {
-                SetCursorPos(x, y);
-                return;
+                return SetCursorPos(x, y).map_err(|err| err.into());
             }
         };
         // if moving time is included, loop is executed that moves step by step
         let start = Instant::now();
-        let start_location = Mouse::get_mouse_position();
+        let start_location = Mouse::get_mouse_position()?;
         let distance_x = x - start_location.0;
         let distance_y = y - start_location.1;
 
@@ -44,42 +46,45 @@ impl Mouse {
 
             unsafe {
                 if time_passed_percentage >= 1.0 {
-                    SetCursorPos(x, y);
-                    break;
+                    return SetCursorPos(x, y).map_err(|err| err.into());
                 } else {
-                    SetCursorPos(new_x as i32, new_y as i32);
+                    let result = SetCursorPos(new_x as i32, new_y as i32).map_err(|err| err.into());
+                    if result.is_err() {
+                        return result;
+                    }
                 }
             }
         }
     }
 
-    pub fn drag_mouse(x: i32, y: i32, moving_time: f32) {
+    pub fn drag_mouse(x: i32, y: i32, moving_time: f32) -> Result<(), AutoGuiError> {
         let (down, up) = (MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP);
         unsafe {
             // set up the first input event (mouse down)
             let mut input_down: INPUT = zeroed();
-            input_down.type_ = INPUT_MOUSE;
-            input_down.u.mi_mut().dwFlags = down;
-            SendInput(1, &mut input_down, size_of::<INPUT>() as i32);
+            input_down.r#type = INPUT_MOUSE;
+            input_down.Anonymous.mi.dwFlags = down;
+            SendInput(&[input_down], size_of::<INPUT>() as i32);
             // wait a bit after click down, before moving
             thread::sleep(time::Duration::from_millis(80));
-            Mouse::move_mouse_to_pos(x, y, moving_time);
+            Mouse::move_mouse_to_pos(x, y, moving_time)?;
             thread::sleep(time::Duration::from_millis(50));
             // set up the second input event (mouse up)
             let mut input_up: INPUT = zeroed();
-            input_up.type_ = INPUT_MOUSE;
-            input_up.u.mi_mut().dwFlags = up;
+            input_up.r#type = INPUT_MOUSE;
+            input_up.Anonymous.mi.dwFlags = up;
             // send the input events
-            SendInput(2, &mut input_up, size_of::<INPUT>() as i32);
+            SendInput(&[input_up], size_of::<INPUT>() as i32);
+            Ok(())
         }
     }
 
     /// returns x, y pixel coordinate of mouse position
-    pub fn get_mouse_position() -> (i32, i32) {
+    pub fn get_mouse_position() -> Result<(i32, i32), AutoGuiError> {
         unsafe {
             let mut point = POINT { x: 0, y: 0 };
-            winapi::um::winuser::GetCursorPos(&mut point);
-            (point.x, point.y)
+            GetCursorPos(&mut point)?;
+            Ok((point.x, point.y))
         }
     }
 
@@ -95,13 +100,13 @@ impl Mouse {
             // create an array of INPUT structures
             let mut inputs: [INPUT; 2] = [zeroed(), zeroed()];
             // set up the first input event (mouse down)
-            inputs[0].type_ = INPUT_MOUSE;
-            inputs[0].u.mi_mut().dwFlags = down;
+            inputs[0].r#type = INPUT_MOUSE;
+            inputs[0].Anonymous.mi.dwFlags = down;
             // set up the second input event (mouse up)
-            inputs[1].type_ = INPUT_MOUSE;
-            inputs[1].u.mi_mut().dwFlags = up;
+            inputs[1].r#type = INPUT_MOUSE;
+            inputs[1].Anonymous.mi.dwFlags = up;
             // send the input events
-            SendInput(2, inputs.as_mut_ptr(), size_of::<INPUT>() as i32);
+            SendInput(&inputs, size_of::<INPUT>() as i32);
         }
     }
 
@@ -116,11 +121,11 @@ impl Mouse {
             // create an array of INPUT structures
             let mut input: INPUT = zeroed();
 
-            input.type_ = INPUT_MOUSE;
-            input.u.mi_mut().dwFlags = down;
+            input.r#type = INPUT_MOUSE;
+            input.Anonymous.mi.dwFlags = down;
 
             // send the input events
-            SendInput(1, &mut input, size_of::<INPUT>() as i32);
+            SendInput(&[input], size_of::<INPUT>() as i32);
         }
     }
 
@@ -135,11 +140,11 @@ impl Mouse {
             // create an array of INPUT structures
             let mut input: INPUT = zeroed();
             // set up thefirstut vent (mous;
-            input.type_ = INPUT_MOUSE;
-            input.u.mi_mut().dwFlags = up;
+            input.r#type = INPUT_MOUSE;
+            input.Anonymous.mi.dwFlags = up;
 
             // send the input events
-            SendInput(1, &mut input, size_of::<INPUT>() as i32);
+            SendInput(&[input], size_of::<INPUT>() as i32);
         }
     }
 
@@ -155,10 +160,10 @@ impl Mouse {
         unsafe {
             let mut scroll_input: INPUT = zeroed();
 
-            scroll_input.type_ = INPUT_MOUSE;
-            scroll_input.u.mi_mut().dwFlags = wheel_direction;
-            scroll_input.u.mi_mut().mouseData = amount as u32;
-            SendInput(1, &mut scroll_input, size_of::<INPUT>() as i32);
+            scroll_input.r#type = INPUT_MOUSE;
+            scroll_input.Anonymous.mi.dwFlags = wheel_direction;
+            scroll_input.Anonymous.mi.mouseData = amount as u32;
+            SendInput(&[scroll_input], size_of::<INPUT>() as i32);
         }
     }
 }

--- a/src/core/screen/windows/mod.rs
+++ b/src/core/screen/windows/mod.rs
@@ -1,20 +1,17 @@
 #[cfg(not(feature = "lite"))]
 extern crate rayon;
-extern crate winapi;
-
-#[cfg(not(feature = "lite"))]
-use image::{GrayImage, ImageBuffer, ImageError, Luma, Rgba};
-use std::mem::size_of;
-use std::ptr::null_mut;
-use winapi::shared::minwindef::{DWORD, HGLOBAL, LPVOID, UINT};
-use winapi::um::wingdi::DIB_RGB_COLORS;
-use winapi::um::wingdi::{
-    BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDIBits,
-    SelectObject, BITMAPINFO, BITMAPINFOHEADER, BI_RGB, RGBQUAD, SRCCOPY,
-};
-use winapi::um::winuser::{GetDC, ReleaseDC};
+extern crate windows;
 
 use crate::{imgtools, AutoGuiError};
+#[cfg(not(feature = "lite"))]
+use image::{GrayImage, ImageBuffer, Luma, Rgba};
+use std::mem::size_of;
+use windows::Win32::Graphics::Gdi::{
+    BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDC, GetDIBits,
+    ReleaseDC, SelectObject, BITMAPINFO, BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS, HBITMAP, HDC,
+    HGDIOBJ, RGBQUAD, SRCCOPY,
+};
+use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN};
 
 #[derive(Debug, Clone)]
 pub struct Screen {
@@ -29,17 +26,17 @@ pub struct ScreenImgData {
     pub screen_region_width: u32,
     pub screen_region_height: u32,
     pub pixel_data: Vec<u8>,
-    h_screen_dc: *mut winapi::shared::windef::HDC__,
-    h_memory_dc: *mut winapi::shared::windef::HDC__,
-    h_bitmap: *mut winapi::shared::windef::HBITMAP__,
+    h_screen_dc: HDC,
+    h_memory_dc: HDC,
+    h_bitmap: HBITMAP,
 }
 
 impl Screen {
     ///Creates struct that holds information about screen
     pub fn new() -> Result<Self, AutoGuiError> {
         unsafe {
-            let screen_width: i32 = winapi::um::winuser::GetSystemMetrics(0);
-            let screen_height = winapi::um::winuser::GetSystemMetrics(1);
+            let screen_width: i32 = GetSystemMetrics(SM_CXSCREEN);
+            let screen_height = GetSystemMetrics(SM_CYSCREEN);
 
             #[cfg(not(feature = "lite"))]
             let screen_data = ScreenImgData {
@@ -47,10 +44,10 @@ impl Screen {
                 screen_region_width: screen_width as u32,
                 pixel_data: vec![0u8; (screen_width * screen_height * 4) as usize],
                 // capture Device Context is a windows struct type that hold information that is written to the screen or printer
-                h_screen_dc: GetDC(null_mut()),
+                h_screen_dc: GetDC(None),
                 // here we create a compatible device context in memory, which will have same properties, and we will tell windows to write a screen to it
-                h_memory_dc: CreateCompatibleDC(GetDC(null_mut())),
-                h_bitmap: CreateCompatibleBitmap(GetDC(null_mut()), screen_width, screen_height),
+                h_memory_dc: CreateCompatibleDC(None),
+                h_bitmap: CreateCompatibleBitmap(GetDC(None), screen_width, screen_height),
             };
             Ok(Screen {
                 screen_height,
@@ -75,9 +72,9 @@ impl Screen {
     /// clear memory and delete screen
     pub fn destroy(&self) {
         unsafe {
-            DeleteObject(self.screen_data.h_bitmap as HGLOBAL);
-            DeleteDC(self.screen_data.h_memory_dc);
-            ReleaseDC(null_mut(), self.screen_data.h_screen_dc);
+            let _ = DeleteObject(HGDIOBJ(self.screen_data.h_bitmap.0));
+            let _ = DeleteDC(self.screen_data.h_memory_dc);
+            let _ = ReleaseDC(None, self.screen_data.h_screen_dc);
         }
     }
     #[cfg(not(feature = "lite"))]
@@ -90,7 +87,7 @@ impl Screen {
         let (x, y, width, height) = region;
         self.screen_data.screen_region_width = width;
         self.screen_data.screen_region_height = height;
-        self.capture_screen();
+        self.capture_screen()?;
         let image = self.convert_bitmap_to_rgba()?;
 
         let cropped_image: ImageBuffer<Rgba<u8>, Vec<u8>> =
@@ -106,7 +103,7 @@ impl Screen {
         let (x, y, width, height) = region;
         self.screen_data.screen_region_width = *width;
         self.screen_data.screen_region_height = *height;
-        self.capture_screen();
+        self.capture_screen()?;
         let image = self.convert_bitmap_to_grayscale()?;
 
         let cropped_image: ImageBuffer<Luma<u8>, Vec<u8>> =
@@ -116,17 +113,17 @@ impl Screen {
     #[cfg(not(feature = "lite"))]
     /// grabs screen image and saves file at provided
     pub fn grab_screenshot(&mut self, image_path: &str) -> Result<(), AutoGuiError> {
-        self.capture_screen();
+        self.capture_screen()?;
         let image = self.convert_bitmap_to_rgba()?;
         Ok(image.save(image_path)?)
     }
     #[cfg(not(feature = "lite"))]
-    fn capture_screen(&mut self) {
+    fn capture_screen(&mut self) -> Result<(), AutoGuiError> {
         unsafe {
             // here we select the memory device context and the bitmap as main ones
             SelectObject(
                 self.screen_data.h_memory_dc,
-                self.screen_data.h_bitmap as HGLOBAL,
+                HGDIOBJ(self.screen_data.h_bitmap.0),
             );
             // this function writes data to memory device context
             BitBlt(
@@ -135,19 +132,19 @@ impl Screen {
                 0,
                 self.screen_width,
                 self.screen_height,
-                self.screen_data.h_screen_dc,
+                Some(self.screen_data.h_screen_dc),
                 0,
                 0,
                 SRCCOPY,
-            );
+            )?;
             let mut bitmap_info = BITMAPINFO {
                 bmiHeader: BITMAPINFOHEADER {
-                    biSize: size_of::<BITMAPINFOHEADER>() as DWORD,
+                    biSize: size_of::<BITMAPINFOHEADER>() as u32,
                     biWidth: self.screen_width,
                     biHeight: -self.screen_height, // Negative to indicate top-down DIB
                     biPlanes: 1,
                     biBitCount: 32,
-                    biCompression: BI_RGB,
+                    biCompression: BI_RGB.0,
                     biSizeImage: 0,
                     biXPelsPerMeter: 0,
                     biYPelsPerMeter: 0,
@@ -171,13 +168,14 @@ impl Screen {
                 self.screen_data.h_memory_dc,
                 self.screen_data.h_bitmap,
                 0,
-                self.screen_height as UINT,
-                bitmap_data.as_mut_ptr() as LPVOID,
+                self.screen_height as u32,
+                Some(bitmap_data.as_mut_ptr() as *mut core::ffi::c_void),
                 &mut bitmap_info,
                 DIB_RGB_COLORS,
             );
 
-            self.screen_data.pixel_data = bitmap_data
+            self.screen_data.pixel_data = bitmap_data;
+            Ok(())
         }
     }
     #[cfg(not(feature = "lite"))]

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -6,6 +6,9 @@ use std::{
 #[cfg(feature = "opencl")]
 use ocl;
 
+#[cfg(target_os = "windows")]
+mod windows;
+
 #[derive(Debug)]
 pub enum AutoGuiError {
     OSFailure(String),

--- a/src/errors/windows/mod.rs
+++ b/src/errors/windows/mod.rs
@@ -1,0 +1,7 @@
+use crate::errors::AutoGuiError;
+
+impl From<windows_result::Error> for AutoGuiError {
+    fn from(err: windows_result::Error) -> Self {
+        AutoGuiError::OSFailure(err.message())
+    }
+}

--- a/src/rustautogui_impl/mouse_impl.rs
+++ b/src/rustautogui_impl/mouse_impl.rs
@@ -8,7 +8,7 @@ impl crate::RustAutoGui {
         #[cfg(target_os = "linux")]
         return self.mouse.get_mouse_position();
         #[cfg(target_os = "windows")]
-        return Ok(Mouse::get_mouse_position());
+        return Mouse::get_mouse_position();
         #[cfg(target_os = "macos")]
         return Mouse::get_mouse_position();
     }
@@ -24,8 +24,7 @@ impl crate::RustAutoGui {
 
         #[cfg(target_os = "windows")]
         {
-            Mouse::move_mouse_to_pos(x as i32, y as i32, moving_time);
-            Ok(())
+            Mouse::move_mouse_to_pos(x as i32, y as i32, moving_time)
         }
         #[cfg(target_os = "linux")]
         return self
@@ -58,8 +57,7 @@ impl crate::RustAutoGui {
 
         #[cfg(target_os = "windows")]
         {
-            Mouse::move_mouse_to_pos(x, y, moving_time);
-            Ok(())
+            Mouse::move_mouse_to_pos(x, y, moving_time)
         }
         #[cfg(target_os = "linux")]
         return self.mouse.move_mouse_to_pos(x, y, moving_time);
@@ -82,10 +80,7 @@ impl crate::RustAutoGui {
         }
 
         #[cfg(target_os = "windows")]
-        {
-            Mouse::move_mouse_to_pos(x, y, moving_time);
-            Ok(())
-        }
+        return Mouse::move_mouse_to_pos(x, y, moving_time);
         #[cfg(target_os = "linux")]
         return self.mouse.move_mouse_to_pos(x, y, moving_time);
         #[cfg(target_os = "macos")]
@@ -105,9 +100,7 @@ impl crate::RustAutoGui {
         };
         #[cfg(target_os = "windows")]
         {
-            Mouse::drag_mouse(x, y, moving_time);
-
-            Ok(())
+            Mouse::drag_mouse(x, y, moving_time)
         }
         #[cfg(target_os = "macos")]
         {
@@ -148,9 +141,7 @@ impl crate::RustAutoGui {
         }
         #[cfg(target_os = "windows")]
         {
-            Mouse::drag_mouse(x, y, moving_time);
-
-            Ok(())
+            Mouse::drag_mouse(x, y, moving_time)
         }
         #[cfg(target_os = "macos")]
         {
@@ -180,9 +171,7 @@ impl crate::RustAutoGui {
 
         #[cfg(target_os = "windows")]
         {
-            Mouse::drag_mouse(x as i32, y as i32, moving_time);
-
-            Ok(())
+            Mouse::drag_mouse(x as i32, y as i32, moving_time)
         }
         #[cfg(target_os = "macos")]
         {


### PR DESCRIPTION
Hello, in preparation to fix a bug I found, relating to DPI scaling on monitors resulting in the wrong size screen size detected by the library (and thus the wrong size screenshot taken of the full screen), I noticed that the library uses an unmaintained crate [`winapi`](https://crates.io/crates/winapi), which is [superseded](https://github.com/retep998/winapi-rs/issues/1055) by the [`windows`](https://crates.io/crates/windows) crate maintained by Microsoft and auto generated based of metadata.

I've ported this project to use the new crate that is actively maintained.